### PR TITLE
Few enhancements for the power saving functionality

### DIFF
--- a/examples/simple_repeater/MyMesh.cpp
+++ b/examples/simple_repeater/MyMesh.cpp
@@ -1116,7 +1116,6 @@ void MyMesh::loop() {
   last_millis = now;
 }
 
-// To get the current pending work
-int MyMesh::hasPendingWork() const {
+int MyMesh::getPendingWorkCount() const {
   return _mgr->getOutboundCount(0xFFFFFFFF);
 }

--- a/examples/simple_repeater/MyMesh.h
+++ b/examples/simple_repeater/MyMesh.h
@@ -226,6 +226,5 @@ public:
   }
 #endif
 
-  // To get the current pending work
-  int hasPendingWork() const;
+  int getPendingWorkCount() const;
 };

--- a/examples/simple_repeater/main.cpp
+++ b/examples/simple_repeater/main.cpp
@@ -132,7 +132,7 @@ void loop() {
 
   if (the_mesh.getNodePrefs()->powersaving_enabled &&
       the_mesh.millisHasNowPassed(lastActive + nextSleepInSecs * 1000)) {
-    if (the_mesh.hasPendingWork() == 0) {
+    if (the_mesh.getPendingWorkCount() == 0) {
       board.sleep(POWERSAVE_SLEEP_DURATION_SECS);
       lastActive = millis();
       nextSleepInSecs = POWERSAVE_WORK_CHECK_SECS;

--- a/src/helpers/CommonCLI.cpp
+++ b/src/helpers/CommonCLI.cpp
@@ -93,6 +93,8 @@ void CommonCLI::loadPrefsInt(FILESYSTEM* fs, const char* filename) {
     _prefs->bridge_baud = constrain(_prefs->bridge_baud, 9600, 115200);
     _prefs->bridge_channel = constrain(_prefs->bridge_channel, 0, 14);
 
+    _prefs->powersaving_enabled = constrain(_prefs->powersaving_enabled, 0, 1);
+
     _prefs->gps_enabled = constrain(_prefs->gps_enabled, 0, 1);
     _prefs->advert_loc_policy = constrain(_prefs->advert_loc_policy, 0, 2);
 

--- a/src/helpers/CommonCLI.h
+++ b/src/helpers/CommonCLI.h
@@ -42,14 +42,14 @@ struct NodePrefs { // persisted to file
   uint32_t bridge_baud;   // 9600, 19200, 38400, 57600, 115200 (default 115200)
   uint8_t bridge_channel; // 1-14 (ESP-NOW only)
   char bridge_secret[16]; // for XOR encryption of bridge packets (ESP-NOW only)
+  // Power saving
+  uint8_t powersaving_enabled; // boolean
   // Gps settings
   uint8_t gps_enabled;
   uint32_t gps_interval; // in seconds
   uint8_t advert_loc_policy;
   uint32_t discovery_mod_timestamp;
   float adc_multiplier;
-  // Power setting
-  uint8_t powersaving_enabled; // boolean
 };
 
 class CommonCLICallbacks {

--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -55,7 +55,7 @@ public:
   // Wakes on: (1) LoRa packet received (DIO1 interrupt), or (2) timer after 'secs' seconds.
   // Only supported on ESP32-S3 with RTC-capable DIO1 pin.
   void sleep(uint32_t secs) override {
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32S3) && defined(P_LORA_DIO_1)
     // Only sleep if DIO1 is an RTC-capable GPIO
     if (!rtc_gpio_is_valid_gpio((gpio_num_t)P_LORA_DIO_1)) return;
 

--- a/src/helpers/esp32/TBeamBoard.h
+++ b/src/helpers/esp32/TBeamBoard.h
@@ -2,16 +2,7 @@
 
 #if defined(TBEAM_SUPREME_SX1262) || defined(TBEAM_SX1262) || defined(TBEAM_SX1276)
 
-#include <Wire.h>
-#include <Arduino.h>
-#include "XPowersLib.h"
-#include "helpers/ESP32Board.h"
-#include <driver/rtc_io.h>
-//#include <RadioLib.h>
-//#include <helpers/RadioLibWrappers.h>
-//#include <helpers/CustomSX1262Wrapper.h>
-//#include <helpers/CustomSX1276Wrapper.h>
-
+// Define pin mappings BEFORE including ESP32Board.h so sleep() can use P_LORA_DIO_1
 #ifdef TBEAM_SUPREME_SX1262
   // LoRa radio module pins for TBeam S3 Supreme SX1262
   #define  P_LORA_DIO_0   -1   //NC
@@ -86,9 +77,16 @@
 #endif
 
 // enum RadioType {
-//   SX1262, 
+//   SX1262,
 //   SX1276
 // };
+
+// Include headers AFTER pin definitions so ESP32Board::sleep() can use P_LORA_DIO_1
+#include <Wire.h>
+#include <Arduino.h>
+#include "XPowersLib.h"
+#include "helpers/ESP32Board.h"
+#include <driver/rtc_io.h>
 
 class TBeamBoard : public ESP32Board {
 XPowersLibInterface *PMU = NULL;


### PR DESCRIPTION
1. Added powersaving_enabled sanitization - CommonCLI.cpp:98 - prevents garbage values from uninitialized prefs
2. Reordered struct field - CommonCLI.h - moved powersaving_enabled to match serialization order (after bridge_secret)
3. Added named constants - main.cpp - replaced magic numbers with POWERSAVE_INITIAL_DELAY_SECS, POWERSAVE_WORK_CHECK_SECS, POWERSAVE_SLEEP_DURATION_SECS
4. Renamed method - MyMesh.cpp/h - hasPendingWork() → getPendingWorkCount() for clarity
5. Conditional WiFi include - ESP32Board.h - WiFi.h and rtc_io.h only included for ESP32-S3
6. Simplified sleep implementation - ESP32Board.h - merged enterLightSleep() into sleep(), all logic under single S3 guard
7. Fix building TBeam board.
