### PR TITLE
Fix NRF52 sleep deadlock, ESP32 WiFi check, and RAK4631 build flag

### DIFF
--- a/src/helpers/ESP32Board.h
+++ b/src/helpers/ESP32Board.h
@@ -71,7 +71,7 @@ public:
     wifi_mode_t mode;
     esp_err_t err = esp_wifi_get_mode(&mode);
 
-    if (err == ESP_OK) { // WiFi is on
+    if (err == ESP_OK && mode != WIFI_MODE_NULL) { // WiFi is active
       return false;
     }
 

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -7,6 +7,7 @@ build_flags = ${nrf52_base.build_flags}
   -I variants/rak4631
   -D RAK_4631
   -D RAK_BOARD
+  -D NRF52_POWER_MANAGEMENT
   -D P_LORA_DIO_1=47
   -D P_LORA_NSS=42
   -D P_LORA_RESET=38


### PR DESCRIPTION
NRF52: Remove nrf_gpio_cfg_sense_input/nrf_gpio_cfg_input on DIO1 pin during sleep. These PIN_CNF writes are unnecessary for System ON idle (GPIOTE from RadioLib already wakes WFE) and risk a rare GPIOTE sampling glitch where the ISR misses a rising edge, leaving DIO1 stuck HIGH with STATE_INT_READY never set — making the radio permanently deaf. Also restore FPU errata 87 workaround that was present in the original sleep() but dropped in the rewrite.

ESP32: Check mode != WIFI_MODE_NULL in safeToSleep() so that stopped WiFi doesn't incorrectly block sleep.

RAK4631: Restore accidentally removed -D NRF52_POWER_MANAGEMENT.